### PR TITLE
use $(metafile) in version expansion

### DIFF
--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -662,7 +662,7 @@ metafile := $(wildcard $(lib.name)-meta.pd)
 ifdef metafile
   lib.version := $(shell sed -n \
     's|^\#X text [0-9][0-9]* [0-9][0-9]* VERSION \(.*\);|\1|p' \
-    $(lib.name)-meta.pd)
+    $(metafile))
 endif
 
 


### PR DESCRIPTION
`lib.version` is only set if the file named by `$(metafile)` exists, but then it uses a hardcoded filename to do the actual expansion.

this patch uses `$(metafile)` to do the expansion instead.