### PR TITLE
allow installed files to contain weirdo characters

### DIFF
--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -1009,13 +1009,15 @@ install: $(if $(datadirs), install-datadirs)
 
 install-executables: all
 	$(INSTALL_DIR) -v "$(installpath)"
-	$(INSTALL_PROGRAM) $(executables) "$(installpath)"
+	$(foreach v, $(executables), \
+	$(INSTALL_PROGRAM) '$v' "$(installpath)";)
 	$(info ++++ info: executables of lib $(lib.name) installed \
         from $(CURDIR) to $(installpath))
 
 install-datafiles: all
 	$(INSTALL_DIR) -v "$(installpath)"
-	$(INSTALL_DATA) $(datafiles) "$(installpath)"
+	$(foreach v, $(datafiles), \
+	$(INSTALL_DATA) '$(v)' "$(installpath)";)
 	$(info ++++ info: data files of lib $(lib.name) installed \
         from $(CURDIR) to $(installpath))
 


### PR DESCRIPTION
...like '$' (e.g. "$arg-help.pd")
by installing them one-by-one and using single-quotes
(so the shell doesn't expand the dollargs)

NOTE: this does not fix compiling such weirdo filenames

Closes: https://github.com/pure-data/pd-lib-builder/issues/19