### PR TITLE
Making minimum Mac OS X version configurable.

### DIFF
--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -891,14 +891,8 @@ $(foreach v, $(classes), $(eval $(declare-class-executable-target)))
 # which case implicit prerequisites are not checked.
 
 # When the Pd include path contains spaces it will mess up the implicit
-# prerequisites rules. Also it is known that multiple arch flags are
-# incompatible with preprocessor option -MM on OSX <= 10.5. Dependency
-# tracking must be disabled in those cases.
-
-oldfat := $(and $(filter ppc i386, $(machine)), \
-          $(filter-out 0 1, $(words $(filter -arch, $(c.flags)))))
-
-disable-dependency-tracking := $(strip $(pdincludepathwithspaces) $(oldfat))
+# prerequisites rules.
+disable-dependency-tracking := $(strip $(pdincludepathwithspaces))
 
 ifndef disable-dependency-tracking
   must-build-everything := $(filter all, $(goals))

--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -539,13 +539,15 @@ ifeq ($(system), Darwin)
   ifeq ($(machine), i386)
     cxx.flags := -fcheck-new
     macosx_version_min ?= 10.4
-    arch.c.flags := -arch ppc -arch i386 -arch x86_64 -mmacosx-version-min=$(macosx_version_min)
-    arch.ld.flags := -arch ppc -arch i386 -arch x86_64 -mmacosx-version-min=$(macosx_version_min)
   endif
   ifeq ($(machine), x86_64)
     macosx_version_min ?= 10.5
-    arch.c.flags := -arch i386 -arch x86_64 -mmacosx-version-min=$(macosx_version_min)
-    arch.ld.flags := -arch i386 -arch x86_64 -mmacosx-version-min=$(macosx_version_min)
+  endif
+  arch.c.flags := -mmacosx-version-min=$(macosx_version_min) -arch i386 -arch x86_64
+  arch.ld.flags := -mmacosx-version-min=$(macosx_version_min) -arch i386 -arch x86_64
+  ifeq ($(macosx_version_min), 10.4)
+    arch.c.flags += -arch ppc
+    arch.ld.flags += -arch ppc
   endif
 endif
 

--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -1,5 +1,5 @@
 # Makefile.pdlibbuilder dated 2016-09-30
-version = 0.2.7
+version = 0.2.8
 
 # Helper makefile for Pure Data external libraries.
 # Written by Katja Vetter March-June 2015 for the public domain. No warranties.

--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -157,6 +157,12 @@ version = 0.2.6
 #      class.sources += linuxthing.c
 #    endef
 #
+# When building externals on Mac using C++11, you will need to set the minimum
+# OS version:
+#    define forDarwin
+#    	macosx_version_min = 10.9
+#    endef
+#
 # makefiles and makefiledirs: 
 # Extra makefiles or directories with makefiles that should be made in sub-make
 # processes.
@@ -532,12 +538,14 @@ ifeq ($(system), Darwin)
   stripflags = -x
   ifeq ($(machine), i386)
     cxx.flags := -fcheck-new
-    arch.c.flags := -arch ppc -arch i386 -arch x86_64 -mmacosx-version-min=10.4
-    arch.ld.flags := -arch ppc -arch i386 -arch x86_64 -mmacosx-version-min=10.4
+    macosx_version_min ?= 10.4
+    arch.c.flags := -arch ppc -arch i386 -arch x86_64 -mmacosx-version-min=$(macosx_version_min)
+    arch.ld.flags := -arch ppc -arch i386 -arch x86_64 -mmacosx-version-min=$(macosx_version_min)
   endif
   ifeq ($(machine), x86_64)
-    arch.c.flags := -arch i386 -arch x86_64 -mmacosx-version-min=10.5
-    arch.ld.flags := -arch i386 -arch x86_64 -mmacosx-version-min=10.5
+    macosx_version_min ?= 10.5
+    arch.c.flags := -arch i386 -arch x86_64 -mmacosx-version-min=$(macosx_version_min)
+    arch.ld.flags := -arch i386 -arch x86_64 -mmacosx-version-min=$(macosx_version_min)
   endif
 endif
 

--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -1,5 +1,5 @@
-# Makefile.pdlibbuilder dated 2016-09-20
-version = 0.2.6
+# Makefile.pdlibbuilder dated 2016-09-30
+version = 0.2.7
 
 # Helper makefile for Pure Data external libraries.
 # Written by Katja Vetter March-June 2015 for the public domain. No warranties.


### PR DESCRIPTION
This is necessary for building externals that use C++11.