### PR TITLE
assume system is "Windows" if uname says "MSYS"

### DIFF
--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -474,6 +474,10 @@ ifeq ($(uname), Darwin)
   system = Darwin
 endif
 
+ifeq ($(findstring MSYS, $(uname)), MSYS)
+  system = Windows
+endif
+
 ifeq ($(findstring MINGW, $(uname)), MINGW)
   system = Windows
 endif

--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -445,7 +445,7 @@ ifeq ($(uname), Darwin)
   system = Darwin
 endif
 
-ifeq ($(filter MINGW% MSYS, $(uname)), $(uname)) 
+ifeq ($(filter MINGW% MSYS%, $(uname)), $(uname)) 
   system = Windows
 endif
 


### PR DESCRIPTION
this is somehow needed for building with pd-lib-builder on [AppVeyor](https://ci.appveyor.com/project/umlaeute/libdir)