### PR TITLE
feature: make support-libraries co-installable

### DIFF
--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -360,6 +360,10 @@ ifneq ($(firstword $(sort 3.81 $(MAKE_VERSION))), 3.81)
   $(error GNU make version 3.81 or higher is required)
 endif
 
+# helper variables
+noop=
+space=$(noop) $(noop)
+
 # Relative path to externals root dir in multi-lib source tree like
 # pd-extended SVN. Default is parent of current working directory. May be
 # defined differently in including makefile.
@@ -435,7 +439,7 @@ classes.executables = $(addsuffix .$(extension), $(classes))
 
 # construct shared lib executable name if shared sources are defined
 ifdef shared.sources
-  shared.lib = lib$(lib.name).$(shared.extension)
+  shared.lib = lib$(lib.name).$(subst $(space),-,$(target.triplet)).$(shared.extension)
 else
   shared.lib =
 endif

--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -917,13 +917,13 @@ endif
 define link-shared
   $(compile-$1) \
   $(shared.ldflags) \
-  -o lib$(lib.name).$(shared.extension) $(shared.objects) \
+  -o $(shared.lib) $(shared.objects) \
   $($1.ldlibs) $(shared.ldlibs)
 endef
 
 # rule for linking objects in shared executable
 # build recipe is in macro 'link-shared'
-lib$(lib.name).$(shared.extension): $(shared.objects)
+$(shared.lib): $(shared.objects)
 	$(info ++++ info: linking objects in shared lib $@)
 	$(if $(filter %.cc %.cpp, $(shared.sources)), \
         $(call link-shared,cxx), \


### PR DESCRIPTION
this implements a solution for the co-installability of support-libraries as outlined in #58 , by adding the arch-triplet of the target architecture to the name of the $(shared.lib).

18d8d0b  is only a cleanup, as i think that hardcoding `lib$(lib.name).$(shared.extension)` as the name of the shared-library is an error if we already have `$(shared.lib)` that expands to the same value.

once we have a single variable for the name of the support-library, it is trivial to jsut add the arch-triplet (the only trick is to undo the splitting of `$(arch.triplet)`