### PR TITLE
macOS d_fat arch detection using Xcode version

### DIFF
--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -79,7 +79,7 @@ version = 0.6.0
 # Variables available for your makefile or make command line:
 #
 # - make-lib-executable
-# - make-lib-fat
+# - make-multi-arch
 # - suppress-wunused
 #
 # Path variables for make command line or environment:
@@ -175,10 +175,10 @@ version = 0.6.0
 # this can still be overridden with 'make-lib-executable=no' as command argument
 # to build individual class executables (the Makefile.pdlibbuilder default.)
 #
-# make-lib-fat:
-# When this variable is defined ('yes' or any other value) in your makefile or
-# as a command argument, Makefile.pdlibbuilder with try to build a "fat"
-# multi-arch binary on supporting platforms.
+# make-multi-arch:
+# When this variable is defined 'yes' in your makefile or as a command argument,
+# Makefile.pdlibbuilder with try to build a "fat" multiple-architecture binary
+# on supporting platforms.
 #
 # suppress-wunused:
 # When this variable is defined ('yes' or any other value), -Wunused-variable,
@@ -515,7 +515,7 @@ ifeq ($(system), Darwin)
   pdincludepath := $(firstword $(wildcard \
     /Applications/Pd*.app/Contents/Resources/src))
   extension = pd_darwin
-  ifeq ($(make-lib-fat),yes)
+  ifeq ($(make-multi-arch),yes)
     extension = d_fat
   endif
   cpp.flags := -DUNIX -DMACOSX -I /sw/include

--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -528,16 +528,12 @@ ifeq ($(system), Darwin)
       xcode.ver := $(shell \
         pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | \
         grep 'version' | sed 's/[^0-9]*\([0-9]*\).*/\1/')
-      ifeq ($(xcode.ver), undefined)
-        $(warn Could not find Xcode version. Using default d_fat archs.)
-        arch := i386 x86_64
-      else ifeq ($(shell [ $(xcode.ver) -gt 11 ] && echo 1), 1)
+      ifeq ($(shell [ $(xcode.ver) -gt 11 ] && echo 1), 1)
         # Xcode 12+
         arch := x86_64 arm64
       else ifeq ($(shell [ $(xcode.ver) -gt 9 ] && echo 1), 1)
         # Xcode 10 - 11
-        $(error Cannot build d_fat. Xcode version $(xcode.ver) \
-                only allows building for $(target.arch).)
+        $(warning Xcode version $(xcode.ver) only builds $(target.arch).)
       else ifeq ($(shell [ $(xcode.ver) -gt 3 ] && echo 1), 1)
         # Xcode 4 - 9
         arch := i386 x86_64
@@ -545,7 +541,9 @@ ifeq ($(system), Darwin)
         # Xcode 3
         arch := ppc i386 x86_64
       else
-        $(error Cannot build d_fat. Unsupported Xcode version $(xcode.ver).)
+        $(warning Unknown or unsupported Xcode version. \
+                  Using $(target.arch) for d_fat.)
+        arch := $(target.arch)
       endif
     endif
   else

--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -536,7 +536,7 @@ ifeq ($(system), Darwin)
       # detect macOS version from Xcode toolchain version & deduce archs
       xcode.ver := $(shell \
         pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | \
-        grep 'version' | sed 's/[^0-9]*\([0-9]*\).*/\1/'
+        grep 'version' | sed 's/[^0-9]*\([0-9]*\).*/\1/' \
       )
       ifeq ($(shell [ $(xcode.ver) -gt 11 ] && echo 1), 1)
         # Xcode 12+

--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -515,7 +515,7 @@ ifeq ($(system), Darwin)
   pdincludepath := $(firstword $(wildcard \
     /Applications/Pd*.app/Contents/Resources/src))
   extension = pd_darwin
-  ifdef ($(make-lib-fat),yes)
+  ifeq ($(make-lib-fat),yes)
     extension = d_fat
   endif
   cpp.flags := -DUNIX -DMACOSX -I /sw/include

--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -434,6 +434,7 @@ $(eval $(for$(system)))
 # x86_64  Intel 64 bit
 # arm     ARM 32 bit
 # aarch64 ARM 64 bit
+# arm64   Apple ARM 64 bit
 
 target.arch := $(firstword $(target.triplet))
 
@@ -522,8 +523,33 @@ ifeq ($(system), Darwin)
     cxx.flags := -fcheck-new
   endif
   ifeq ($(extension), d_fat)
-    arch := i386 x86_64
+    ifeq ($(origin arch), undefined)
+      # detect macOS version from Xcode toolchain version & deduce archs
+      xcode.ver := $(shell \
+        pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | \
+        grep 'version' | sed 's/[^0-9]*\([0-9]*\).*/\1/')
+      ifeq ($(xcode.ver), undefined)
+        $(warn Could not find Xcode version. Using default d_fat archs.)
+        arch := i386 x86_64
+      else ifeq ($(shell [ $(xcode.ver) -gt 11 ] && echo 1), 1)
+        # Xcode 12+
+        arch := x86_64 arm64
+      else ifeq ($(shell [ $(xcode.ver) -gt 9 ] && echo 1), 1)
+        # Xcode 10 - 11
+        $(error Cannot build d_fat. Xcode version $(xcode.ver) \
+                only allows building for $(target.arch).)
+      else ifeq ($(shell [ $(xcode.ver) -gt 3 ] && echo 1), 1)
+        # Xcode 4 - 9
+        arch := i386 x86_64
+      else ifeq ($(xcode.ver), 3)
+        # Xcode 3
+        arch := ppc i386 x86_64
+      else
+        $(error Cannot build d_fat. Unsupported Xcode version $(xcode.ver).)
+      endif
+    endif
   else
+    # build for current arch only
     arch := $(target.arch)
   endif
   ifneq ($(filter -mmacosx-version-min=%, $(cflags)),)
@@ -798,6 +824,11 @@ ifeq ($(goals), all)
   $(if $(mpdh), \
     $(info ++++ info: using Pd API $(mpdh)), \
     $(warning Where is Pd API m_pd.h? Do 'make help' for info.))
+endif
+
+# confirm mac fat build
+ifeq ($(extension), d_fat)
+  $(info ++++ info: making d_fat for archs $(arch))
 endif
 
 # print target info

--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -79,6 +79,7 @@ version = 0.6.0
 # Variables available for your makefile or make command line:
 #
 # - make-lib-executable
+# - make-lib-fat
 # - suppress-wunused
 #
 # Path variables for make command line or environment:
@@ -173,6 +174,11 @@ version = 0.6.0
 # If your makefile defines 'make-lib-executable=yes' as the library default,
 # this can still be overridden with 'make-lib-executable=no' as command argument
 # to build individual class executables (the Makefile.pdlibbuilder default.)
+#
+# make-lib-fat:
+# When this variable is defined ('yes' or any other value) in your makefile or
+# as a command argument, Makefile.pdlibbuilder with try to build a "fat"
+# multi-arch binary on supporting platforms.
 #
 # suppress-wunused:
 # When this variable is defined ('yes' or any other value), -Wunused-variable,
@@ -508,7 +514,10 @@ ifeq ($(system), Darwin)
   pkglibdir = $(HOME)/Library/Pd
   pdincludepath := $(firstword $(wildcard \
     /Applications/Pd*.app/Contents/Resources/src))
-  extension ?= pd_darwin
+  extension = pd_darwin
+  ifdef ($(make-lib-fat),yes)
+    extension = d_fat
+  endif
   cpp.flags := -DUNIX -DMACOSX -I /sw/include
   c.flags :=
   c.ldflags := -undefined suppress -flat_namespace -bundle

--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -535,7 +535,7 @@ ifeq ($(system), Darwin)
     ifeq ($(origin arch), undefined)
       # detect macOS version from Xcode toolchain version & deduce archs
       xcode.ver := $(shell \
-        pkgutil --pkg-info=com.apple.pkg.CLTools_Executables &>/dev/null | \
+        pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | \
         grep 'version' | sed 's/[^0-9]*\([0-9]*\).*/\1/' \
       )
       ifeq ($(xcode.ver),)

--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -508,7 +508,7 @@ ifeq ($(system), Darwin)
   pkglibdir = $(HOME)/Library/Pd
   pdincludepath := $(firstword $(wildcard \
     /Applications/Pd*.app/Contents/Resources/src))
-  extension = pd_darwin
+  extension ?= pd_darwin
   cpp.flags := -DUNIX -DMACOSX -I /sw/include
   c.flags :=
   c.ldflags := -undefined suppress -flat_namespace -bundle

--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -536,7 +536,8 @@ ifeq ($(system), Darwin)
       # detect macOS version from Xcode toolchain version & deduce archs
       xcode.ver := $(shell \
         pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | \
-        grep 'version' | sed 's/[^0-9]*\([0-9]*\).*/\1/')
+        grep 'version' | sed 's/[^0-9]*\([0-9]*\).*/\1/'
+      )
       ifeq ($(shell [ $(xcode.ver) -gt 11 ] && echo 1), 1)
         # Xcode 12+
         arch := x86_64 arm64
@@ -551,8 +552,8 @@ ifeq ($(system), Darwin)
         arch := ppc i386 x86_64
       else
         $(warning Unknown or unsupported Xcode version. \
-                  Using $(target.arch) for d_fat.)
-        arch := $(target.arch)
+                  Trying i386 x86_64 for d_fat.)
+        arch := i386 x86_64
       endif
     endif
   else

--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -535,9 +535,15 @@ ifeq ($(system), Darwin)
     ifeq ($(origin arch), undefined)
       # detect macOS version from Xcode toolchain version & deduce archs
       xcode.ver := $(shell \
-        pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | \
+        pkgutil --pkg-info=com.apple.pkg.CLTools_Executables &>/dev/null | \
         grep 'version' | sed 's/[^0-9]*\([0-9]*\).*/\1/' \
       )
+      ifeq ($(xcode.ver),)
+        # no CLTools, try xcodebuild
+        xcode.ver := $(shell xcodebuild -version | \
+          grep 'Xcode' | sed 's/[^0-9]*\([0-9]*\).*/\1/') \
+        )
+      endif
       ifeq ($(shell [ $(xcode.ver) -gt 11 ] && echo 1), 1)
         # Xcode 12+
         arch := x86_64 arm64

--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -541,7 +541,7 @@ ifeq ($(system), Darwin)
       ifeq ($(xcode.ver),)
         # no CLTools, try xcodebuild
         xcode.ver := $(shell xcodebuild -version | \
-          grep 'Xcode' | sed 's/[^0-9]*\([0-9]*\).*/\1/') \
+          grep 'Xcode' | sed 's/[^0-9]*\([0-9]*\).*/\1/' \
         )
       endif
       ifeq ($(shell [ $(xcode.ver) -gt 11 ] && echo 1), 1)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,32 @@ exposed as user variables, although technically all makefile variables can be
 overridden by make command arguments.
 
 
+#### macOS fat libs ####
+
+
+Most versions of macOS can produce "fat libs" with multiple architectures in the
+same binary. Set the `extension` variable to "d_fat" to trigger a fat build:
+
+    make extension=d_fat
+
+Makefile.pdlibbuilder will try to deduce the supported architectures depending
+on the version of Xcode (or it's commandline tools) found:
+
+| Xcode version | macOS version | Architectures   |
+| ------------- | ------------- | --------------- |
+| 3             | 10.6          | ppc i386 x86_64 |
+| 4 - 9         | 10.7 - 10.13  | i386 x86_64     |
+| 10 - 11       | 10.14 - 10.15 | x86_64\*        |
+| 12            | 10.15 - 11+   | x86_64 arm64    |
+
+\***Note: Xcode 10 - 11 only builds for x86_64 and an error will be thrown as
+continuing would not result in a fat lib.**
+
+To override autodetection, set the `arch` variable directly. For example, to
+force 32 & 64 bit Intel:
+
+    make extension=d_fat arch="i386 x86_64"
+
 ### specific language versions ###
 
 

--- a/README.md
+++ b/README.md
@@ -88,42 +88,6 @@ exposed as user variables, although technically all makefile variables can be
 overridden by make command arguments.
 
 
-#### macOS fat libs ####
-
-
-Most versions of macOS can produce "fat libs" with multiple architectures in the
-same binary. Set the `extension` variable to "d_fat" to trigger a fat build:
-
-    make extension=d_fat
-
-Makefile.pdlibbuilder will try to deduce the supported architectures depending
-on the version of Xcode (or it's commandline tools) found:
-
-| Xcode version | macOS version | Architectures   |
-| ------------- | ------------- | --------------- |
-| 3             | 10.6          | ppc i386 x86_64 |
-| 4 - 9         | 10.7 - 10.13  | i386 x86_64     |
-| 10 - 11       | 10.14 - 10.15 | x86_64\*        |
-| 12            | 10.15 - 11+   | x86_64 arm64    |
-
-\***Note: Xcode 10 - 11 only builds for x86_64 and an error will be thrown as
-continuing would not result in a fat lib.**
-
-To override autodetection, set the `arch` variable directly. For example, to
-force 32 & 64 bit Intel:
-
-    make extension=d_fat arch="i386 x86_64"
-
-To print the architectures within a build, use the `file` command:
-
-```shell
-% file myexternal.d_fat
-% myexternal.d_fat: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit bundle x86_64] [arm64:Mach-O 64-bit bundle arm64]
-% myexternal.d_fat (for architecture x86_64):	Mach-O 64-bit bundle x86_64
-% myexternal.d_fat (for architecture arm64):	Mach-O 64-bit bundle arm64
-```
-
-
 ### specific language versions ###
 
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ force 32 & 64 bit Intel:
 
     make extension=d_fat arch="i386 x86_64"
 
+To print the architectures within a build, use the `file` command:
+
+```shell
+% file myexternal.d_fat
+% myexternal.d_fat: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit bundle x86_64] [arm64:Mach-O 64-bit bundle arm64]
+% myexternal.d_fat (for architecture x86_64):	Mach-O 64-bit bundle x86_64
+% myexternal.d_fat (for architecture arm64):	Mach-O 64-bit bundle arm64
+```
+
+
 ### specific language versions ###
 
 

--- a/tips-tricks.md
+++ b/tips-tricks.md
@@ -52,14 +52,43 @@ easily build your externals for this environment with
 
    make CPPFLAGS="-DPD_LONGINTTYPE=__int64" CC=x86_64-w64-mingw32-gcc
 
-
 To build a double-precision external for W64, use something like:
 
    make CPPFLAGS="-DPD_LONGINTTYPE=__int64 -DPD_FLOATSIZE=64" CC=x86_64-w64-mingw32-gcc
 
+#### macOS fat libs ####
 
-## TODO universal binaries on OSX
+Most versions of macOS can produce "fat libs" with multiple architectures in the
+same binary. Set the `make-lib-fat` switch to "yes" to trigger a fat build,
+either in a makefile or on the commandline:
 
+    make make-lib-fat=yes
+
+Makefile.pdlibbuilder will try to deduce the supported architectures depending
+upon the version of Xcode (or it's commandline tools) found:
+
+| Xcode version | macOS version | Architectures   |
+| ------------- | ------------- | --------------- |
+| 3             | 10.6          | ppc i386 x86_64 |
+| 4 - 9         | 10.7 - 10.13  | i386 x86_64     |
+| 10 - 11       | 10.14 - 10.15 | x86_64\*        |
+| 12            | 10.15 - 11+   | x86_64 arm64    |
+
+\***Note: Xcode 10 - 11 only builds for x86_64.**
+
+To override autodetection, set the `arch` variable directly. For example, to
+force 32 & 64 bit Intel:
+
+    make make-lib-fat=yes arch="i386 x86_64"
+
+To print the architectures within a build, use the `file` command:
+
+```shell
+% file myexternal.d_fat
+% myexternal.d_fat: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit bundle x86_64] [arm64:Mach-O 64-bit bundle arm64]
+% myexternal.d_fat (for architecture x86_64): Mach-O 64-bit bundle x86_64
+% myexternal.d_fat (for architecture arm64):  Mach-O 64-bit bundle arm64
+```
 
 # Project management
 

--- a/tips-tricks.md
+++ b/tips-tricks.md
@@ -59,10 +59,10 @@ To build a double-precision external for W64, use something like:
 #### macOS fat libs ####
 
 Most versions of macOS can produce "fat libs" with multiple architectures in the
-same binary. Set the `make-lib-fat` switch to "yes" to trigger a fat build,
+same binary. Set the `make-multi-arch` switch to "yes" to trigger a fat build,
 either in a makefile or on the commandline:
 
-    make make-lib-fat=yes
+    make make-multi-arch=yes
 
 Makefile.pdlibbuilder will try to deduce the supported architectures depending
 upon the version of Xcode (or it's commandline tools) found:
@@ -74,12 +74,7 @@ upon the version of Xcode (or it's commandline tools) found:
 | 10 - 11       | 10.14 - 10.15 | x86_64\*        |
 | 12            | 10.15 - 11+   | x86_64 arm64    |
 
-\***Note: Xcode 10 - 11 only builds for x86_64.**
-
-To override autodetection, set the `arch` variable directly. For example, to
-force 32 & 64 bit Intel:
-
-    make make-lib-fat=yes arch="i386 x86_64"
+\***Note: Xcode 10 - 11 removed 32 bit support and only builds for x86_64.**
 
 To print the architectures within a build, use the `file` command:
 


### PR DESCRIPTION
This PR adds auto detection of the available target architectures when performing a "fat lib" build on macOS. An override is also provided if the `arch` variable is set when building.

Note: I notice that if I try to set the extension variable to trigger the fat lib build, it will only work from the command line and not from within a Makefile. I'd like to be able to do the following:

```makefile
# build macOS fat lib
define forDarwin
  extension ?= d_fat
endef
```

EDIT: The Xcode version detection comes from [Caffee](https://github.com/BVLC/caffe/blob/master/Makefile#L399).

Also, I'm pretty sure `pkgutil` is available all the way back to OSX 10.6 as the man page is dated March 2011 and 10.7 was release in summer of 2011. Can someone try on a 10.6 machine to make sure?
