### PR TITLE
support building multiple flavours

### DIFF
--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -442,6 +442,14 @@ target.arch := $(firstword $(target.triplet))
 ### variables per platform #####################################################
 ################################################################################
 
+#=== flags per floatsize == ====================================================
+floatsize = 32
+ifneq ($(filter-out 32,$(floatsize)),)
+  floatsize.flags = -DPD_FLOATSIZE=$(floatsize)
+else
+  floatsize.flags =
+endif
+
 
 #=== flags per architecture ====================================================
 
@@ -584,14 +592,14 @@ ifeq ($(system), Windows)
   extension = dll
   c.flags :=
   c.ldflags := -static-libgcc -shared \
-    -Wl,--enable-auto-import "$(PDBINDIR)/pd.dll"
+    -Wl,--enable-auto-import "$(PDBINDIR)/pd$(filter-out 32,$(floatsize)).dll"
   c.ldlibs :=
   cxx.flags := -fcheck-new
   cxx.ldflags := -static-libgcc -static-libstdc++ -shared \
-    -Wl,--enable-auto-import "$(PDBINDIR)/pd.dll"
+    -Wl,--enable-auto-import "$(PDBINDIR)/pd$(filter-out 32,$(floatsize)).dll"
   cxx.ldlibs :=
   shared.extension = dll
-  shared.ldflags := -static-libgcc -shared "$(PDBINDIR)/pd.dll"
+  shared.ldflags := -static-libgcc -shared "$(PDBINDIR)/pd$(filter-out 32,$(floatsize)).dll"
   stripflags = --strip-all
 endif
 
@@ -639,7 +647,7 @@ endif
 CFLAGS = $(warn.flags) $(optimization.flags) $(arch.c.flags)
 
 # preprocessor flags
-cpp.flags := -DPD -I "$(PDINCLUDEDIR)" $(cpp.flags) $(CPPFLAGS)
+cpp.flags := -DPD -I "$(PDINCLUDEDIR)" $(floatsize.flags) $(cpp.flags) $(CPPFLAGS)
 
 # flags for dependency checking (cflags from makefile may define -I options)
 depcheck.flags := $(cpp.flags) $(cflags)
@@ -792,7 +800,7 @@ endif
 
 # store path to pd.dll; if not found, ls will give a useful error
 ifeq ($(system), Windows)
-  pddll := $(shell ls "$(PDBINDIR)/pd.dll")
+  pddll := $(shell ls "$(PDBINDIR)/pd$(filter-out 32,$(floatsize)).dll")
 endif
 
 # when making target all, check if m_pd.h is found and print info about it

--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -102,6 +102,8 @@ version = 0.6.0
 # Optional user variables for make command line or environment:
 #
 # - PLATFORM
+# - extension
+# - floatsize
 #
 # Deprecated path variables:
 #
@@ -204,6 +206,19 @@ version = 0.6.0
 # pdlibbuilder will use, if installed and locatable. System and architecture
 # will then be autodefined accordingly. In most cases no other variables need to
 # be overridden.
+#
+# extension:
+# Extension for the external to use. Example: m_amd64
+# A sane default is picked, but it is useful if you want to provide
+# co-installable externals for multiple platforms (for the same operating
+# systems)
+#
+# floatsize:
+# the size of the t_float in bits. Example: 32
+# t_float are usually single precision (32bit), which is the default.
+# For double precision use floatsize=64
+# When building double precision externals, you will want to set the extension
+# as well, e.g. extension=windows-amd64-64.dll (<system>-<cpu>-<floatsize>.<ext>)
 #
 # CPPFLAGS:
 # Preprocessor flags which are not strictly required for building.

--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -683,6 +683,7 @@ endif
 ### variables: files ###########################################################
 ################################################################################
 
+object.extension = $(extension).o
 
 #=== sources ===================================================================
 
@@ -709,10 +710,10 @@ all.sources := $(classes.sources) $(lib.setup.sources) \
 
 
 # construct object filenames from all C and C++ source file names
-classes.objects := $(addsuffix .o, $(basename $(classes.sources)))
-common.objects := $(addsuffix .o, $(basename $(common.sources)))
-shared.objects := $(addsuffix .o, $(basename $(shared.sources)))
-lib.setup.objects := $(addsuffix .o, $(basename $(lib.setup.sources)))
+classes.objects := $(addsuffix .$(object.extension), $(basename $(classes.sources)))
+common.objects := $(addsuffix .$(object.extension), $(basename $(common.sources)))
+shared.objects := $(addsuffix .$(object.extension), $(basename $(shared.sources)))
+lib.setup.objects := $(addsuffix .$(object.extension), $(basename $(lib.setup.sources)))
 all.objects = $(classes.objects) $(common.objects) $(shared.objects) \
   $(lib.setup.objects)
 
@@ -723,12 +724,13 @@ all.objects = $(classes.objects) $(common.objects) $(shared.objects) \
 # construct class executable names from class names
 classes.executables := $(addsuffix .$(extension), $(classes))
 
-# Construct shared lib executable name if shared sources are defined. If
-# extension and shared extension are not identical, use both to facilitate co-
-# installation for different platforms, like .m_i386.dll and .m_amd64.dll.
+# Construct shared lib executable name if shared sources are defined.
+# If extension does not end with shared extension, use both to facilitate co-
+# installation for different platforms, like .m_i386.dll and .linux-amd64-32.so
 ifdef shared.sources
-  ifeq ($(extension), $(shared.extension))
-    shared.lib = lib$(lib.name).$(shared.extension)
+  ifneq ($(filter %.$(shared.extension), .$(extension)), )
+    # $(extension) already ends with $(shared.extension), no need to duplicate it
+    shared.lib = lib$(lib.name).$(extension)
   else
     shared.lib = lib$(lib.name).$(extension).$(shared.extension)
   endif
@@ -874,8 +876,8 @@ define link-class
   $(compile-$1) \
   $($1.ldflags) $($2.class.ldflags) \
   -o $2.$(extension) \
-  $(addsuffix .o, $(basename $($2.class.sources))) \
-  $(addsuffix .o, $(basename $(common.sources))) \
+  $(addsuffix .$(object.extension), $(basename $($2.class.sources))) \
+  $(addsuffix .$(object.extension), $(basename $(common.sources))) \
   $($1.ldlibs) $($2.class.ldlibs) $(shared.lib)
 endef
 
@@ -949,13 +951,13 @@ endef
 # Three rules to create .o files. These are double colon 'terminal' rules,
 # meaning they are the last in a rules chain.
 
-%.o:: %.c
+%.$(object.extension):: %.c
 	$(call make-object-file,c)
 
-%.o:: %.cc
+%.$(object.extension):: %.cc
 	$(call make-object-file,cxx)
 
-%.o:: %.cpp
+%.$(object.extension):: %.cpp
 	$(call make-object-file,cxx)
 
 
@@ -974,8 +976,8 @@ endef
 # declare explicit prerequisites rule like 'class.extension: object1.o object2.o'
 # argument $v is class basename
 define declare-class-executable-target
-$v.$(extension): $(addsuffix .o, $(basename $($v.class.sources))) \
-  $(addsuffix .o, $(basename $(common.sources)))
+$v.$(extension): $(addsuffix .$(object.extension), $(basename $($v.class.sources))) \
+  $(addsuffix .$(object.extension), $(basename $(common.sources)))
 endef
 
 # evaluate explicit prerequisite rules for all classes
@@ -1005,7 +1007,7 @@ endif
 # argument $1 is input source file(s)
 # dir is explicitly added because option -MM strips it by default
 define declare-object-target
-$(dir $1)$(filter %.o: %.h, $(shell $(CPP) $(depcheck.flags) -MM $1)) $(MAKEFILE_LIST)
+$(dir $1)$(patsubst %.o:,%.$(object.extension):,$(filter %.o: %.h, $(shell $(CPP) $(depcheck.flags) -MM $1))) $(MAKEFILE_LIST)
 endef
 
 # evaluate implicit prerequisite rules when rebuilding everything


### PR DESCRIPTION
this PR allows building an external for multiple flavours (operating systems, CPU-architectures, **floatsizes**) without having to go through an intermediate 'clean'.


```sh
## build
make
make extension=linux-amd64-64.so CPPFLAGS=-DPD_FLOATSIZE=64
### install
make install
make install extension=linux-amd64-64.so
```

this is accomplished with two changes:
- object-files now encode the extension in their filename (e.g. *helloworld.pd_linux.o* instead of *helloworld.o*). this uses the new `$(object.extension)` variable
- avoid duplicate extensions for shared libraries (*libhelloworld.linux-amd64-64.so* rather than ~~*libhelloworld.linux-amd64-64.so.so*~~)

# reasoning

### add `extension` to object-files
since single- and double-precision objects are of the same architecture,
the linker will happily link a single-precision .o file into a double-precision library.
this yields undefined behaviour (and most likely: crashes) at runtime.

since double-precision externals are mandated to have a different extension this is an easy way to keep the .o files apart.

if you don't care about single/double precision, but compile for mulitple platforms, using a single `.o` extension gives you loads of errors if you forget to `make clean` when switching to a compiler for a different architecture.


old behaviour:
```
$ make system=Windows CC=x86_64-w64-mingw32-gcc PDDIR="${PDWIN64}"
[...]
x86_64-w64-mingw32-gcc -static-libgcc -shared -Wl,--enable-auto-import "${PDWIN64}/bin/pd.dll"    -o helloworld.dll helloworld.o     libhelloworld.dll
++++info: target all in lib helloworld completed

$ make
[...]
++++ info: linking objects in shared lib libhelloworld.pd_linux.so
cc -rdynamic -fPIC -shared -Wl,-soname,libhelloworld.pd_linux.so  -o libhelloworld.pd_linux.so foo.o -lc -lm  
/usr/bin/ld: warning: foo.o: missing .note.GNU-stack section implies executable stack
/usr/bin/ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
foo.o:foo.c:(.pdata+0x0): dangerous relocation: R_AMD64_IMAGEBASE with __ImageBase undefined
foo.o:foo.c:(.pdata+0x4): dangerous relocation: R_AMD64_IMAGEBASE with __ImageBase undefined
foo.o:foo.c:(.pdata+0x8): dangerous relocation: R_AMD64_IMAGEBASE with __ImageBase undefined
collect2: error: ld returned 1 exit status
make: *** [pd-lib-builder//Makefile.pdlibbuilder:932: libhelloworld.pd_linux.so] Error 1
```

new behaviour:
```
$ make system=Windows CC=x86_64-w64-mingw32-gcc PDDIR="${PDWIN64}"
[...]
++++ info: linking objects in helloworld.dll for lib helloworld
x86_64-w64-mingw32-gcc -static-libgcc -shared -Wl,--enable-auto-import "${PDWIN64}/bin/pd.dll"    -o helloworld.dll helloworld.dll.o     libhelloworld.dll
++++info: target all in lib helloworld completed

$ make
[...]
++++ info: linking objects in helloworld.pd_linux for lib helloworld
cc -rdynamic -shared -fPIC -Wl,-rpath,"\$ORIGIN",--enable-new-dtags    -o helloworld.pd_linux helloworld.pd_linux.o  -lc -lm   libhelloworld.pd_linux.so
++++info: target all in lib helloworld completed
```


### check if `extension` adds in `shared.extension`
double-precision externals always use the "system-native" extension,  prefixed by some deken-specifier (e.g. "helloworld.linux-i386-64.so").

since the deken-specifier prefix makes the full extension different from the shared.extension (".so"), the old test was insufficient to prevent abominations like "libhelloworld.linux-i386-64.so.so".

https://github.com/pure-data/pd-lib-builder/blob/f1963befabadf9e4804995b42f24999e2afd87a2/Makefile.pdlibbuilder#L731-L736
  

## what's wrong with the olde way?
apart from the two reasons given above (incompatible object files, ugly shared library names), there's also another reason from a packager's point of view:
I really would like to be able to keep the build stages separate from the install stages.

currently, I could do something like this:

```
## single precision
make
make install
make clean
### install
make extension=linux-amd64-64.so CPPFLAGS=-DPD_FLOATSIZE=64
make install extension=linux-amd64-64.so
make clean extension=linux-amd64-64.so
```

but sometimes (e.g. with my Debian developer hat on), there are frameworks that ~~push~~nudge you to keeping the `make`, `make install`, and `make clean` stages separate.
The "normal" solution to this problem is to allow out-of-tree builds, but this has been more-or-less rejected (#2) - with good reasons.
So in order to be able to provide Debian packages for both single and double precision, this PR would really help me :-)

Also, the intermediate `make clean` cleans up one of the flavours, which makes it more inconvenient to develop (and test) an external for single- and double-precision simultaneously.

# UPDATE
after the discussion with @Lucarda (see below), I've now also added a `floatsize` variable, that
- adds `-DPD_FLOATSIZE` as appropriate to the preprocessor flags
- (on Windows) links the external against `pd64.dll` (as appropriate)