### PR TITLE
add -lstdc++ to c.ldlibs on linux

### DIFF
--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -511,7 +511,7 @@ ifeq ($(system), Linux)
   cpp.flags := -DUNIX
   c.flags := -fPIC
   c.ldflags := -rdynamic -shared -fPIC -Wl,-rpath,"\$$ORIGIN",--enable-new-dtags
-  c.ldlibs := -lc -lm
+  c.ldlibs := -lc -lm -lstdc++
   cxx.flags := -fPIC -fcheck-new
   cxx.ldflags := -rdynamic -shared -fPIC -Wl,-rpath,"\$$ORIGIN",--enable-new-dtags
   cxx.ldlibs := -lc -lm -lstdc++
@@ -1362,4 +1362,3 @@ coffee:
 
 # for syntax highlighting in vim and github
 # vim: set filetype=make:
-


### PR DESCRIPTION
Today I had an issue on Debian 12 that I got symbol errors when loading my externals. Both with gcc (12) and llvm (14).

This additional flag was required for proper linking from c to c++ externs.