### PR TITLE
(also) test target.triplet for "windows" for detecting Windows builds

### DIFF
--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -430,7 +430,7 @@ ifneq ($(filter darwin%, $(target.triplet)),)
   system = Darwin
 endif
 
-ifneq ($(filter mingw% cygwin%, $(target.triplet)),)
+ifneq ($(filter mingw% cygwin% windows%, $(target.triplet)),)
   system = Windows
 endif
 


### PR DESCRIPTION
MSYS2/MinGW64/clangarm64 reports `aarch64-w64-windows-gnu` as the architecture...

Closes: https://github.com/pure-data/pd-lib-builder/issues/83